### PR TITLE
[fix?] init self.norm_t_2 at self.last_epoch = 1

### DIFF
--- a/abel/abel.py
+++ b/abel/abel.py
@@ -73,6 +73,7 @@ class ABEL(optim.lr_scheduler._LRScheduler):
             self.current_norm = get_weight_norm(self.optimizer.param_groups)
         elif self.last_epoch == 1:
             self.norm_t_1 = self.current_norm
+            self.norm_t_2 = self.current_norm
             self.current_norm = get_weight_norm(self.optimizer.param_groups)
 
         super(ABEL, self).step(epoch)


### PR DESCRIPTION
hi, tour de ml . think you for your contribution. this repo is simple and clean. but I encountered a small bug when using it to train the model at self.last_epoch = 1.
```bash
File "/home/hova/anaconda3/lib/python3.7/site-packages/abel/abel.py", line 54, in _get_closed_form_lr
  assert self.norm_t_2 is not None
```

To fix this, i  directly make **self.norm_t_2 = self.norm_t_1** at self.last_poch == 1. is that all right? Orz 